### PR TITLE
Development Updates, Feature additions, Bug Fixes

### DIFF
--- a/zettaknight.d/diskperf_one_run.sh
+++ b/zettaknight.d/diskperf_one_run.sh
@@ -52,8 +52,8 @@ function check_if_integer () {
         local var=$1
         if ! [[ $var =~ ^[-+]?[0-9]+$ ]]; then #test if input is an integer
         echo "$var is not an integer"
-                                show_help
-                exit 1
+            show_help
+            exit 1
         fi
 }
 

--- a/zettaknight.d/luks_disk_create.sh
+++ b/zettaknight.d/luks_disk_create.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+#source helper functions
+running_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+setopts="${running_dir}/setopts.sh"
+source $setopts || { echo "failed to source $setopts"; exit 1; }
+zpool="/sbin/zpool"
+
+function show_help () {
+cat << EOF
+version $version
+
+    DESCRIPTION:
+        $(basename $0) is used to create a luks container on a disk.
+
+    $setopts_help
+EOF
+}
+
+function check_previous () {
+    ret_val=$?
+    
+    if [ "$ret_val" -ne 0 ]; then
+        echo "${ret_val}: $@"
+        exit 1
+    fi
+}
+
+set -e
+
+setopts var "-d|--disk" "disk" "disk create a luks container on"
+setopts var "-k|--keyfile" "keyfile" "keyfile to be added to luks disk."
+
+if [ -z "$keyfile" ] || [ -z "$disk" ]; then
+
+    echo -e "\nrequired arguments missing\n"
+    show_help
+    exit 1
+
+fi
+
+if ! [ -e "$keyfile" ] || ! [ -e "$disk" ] ; then
+
+    echo "$keyfile or $disk does not exist"
+    show_help
+    exit 1
+        
+fi
+
+password="as;lsda;kDFSajgjlk4;kj4a;derp" #default password, will be removed once a key is added to the container
+#kirby=([1]="<(o_0<)" [2]="<(o_0)>" [3]="(>o_0)>" [4]="<(o_0)>")
+
+luks_name=$(echo $disk | sed 's/[/]//g')
+
+#cryptsetup luksClose $luks_name || echo "$luks_name is not mounted"
+
+echo -e "\ncreating luks container $luks_name\n\tcryptsetup --cipher aes-xts-plain --key-size 512 --hash sha256 luksFormat $disk <<< <password omitted>"
+sudo cryptsetup --cipher aes-xts-plain --key-size 512 --hash sha256 luksFormat $disk <<< $password
+check_previous "failed to create LUKS volume on $disk"
+
+echo -e "\nadding keyfile $keyfile to $luks_name\n\tcryptsetup luksAddKey $disk $keyfile <<< <password omitted>"
+sudo cryptsetup luksAddKey $disk $keyfile <<< $password
+check_previous "failed to add $keyfile to $disk"
+
+echo -e "\nmounting $luks_name\n\tcryptsetup luksOpen $disk $luks_name <<< <password omitted>"
+sudo cryptsetup luksOpen $disk $luks_name <<< $password
+check_previous "failed to mount LUKS volume $disk as $luks_name"
+
+echo -e "\nconfiguring /etc/crypttab\n\t$luks_name\t$disk\t$keyfile\tluks"
+echo -e "$luks_name\t$disk\t$keyfile\tluks" >> /etc/crypttab
+check_previous "failed to add information to /etc/crypttab"
+
+#remove original key
+echo -e "\nremoving default password\n\tcryptsetup luksKillSlot $disk 0 --key-file $keyfile"
+sudo cryptsetup luksKillSlot $disk 0 --key-file $keyfile
+check_previous "failed to remove key slot 0"

--- a/zettaknight.d/replace_disk.sh
+++ b/zettaknight.d/replace_disk.sh
@@ -17,13 +17,12 @@
 #    You should have received a copy of the GNU General Public License
 #    along with Zettaknight.  If not, see <http://www.gnu.org/licenses/>.
 #
-version="0.0.3"
+version="0.0.4"
 
 #source helper functions
 running_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 setopts="${running_dir}/setopts.sh"
 source $setopts || { echo "failed to source $setopts"; exit 1; }
-beacon="${running_dir}/beacon_all.sh"
 zpool="/sbin/zpool"
 
 function show_help () {
@@ -50,211 +49,18 @@ function check_previous () {
     fi
 }
 
-#if which smartctl > /dev/null; then
-#                echo -e "\ngrabbing statistics for $disk"
-#                smartctl -H /dev/${smart_disk}
-#            else
-#                echo "smartctl is needed for extended disk statistics"
-#            fi
+set -e
 
-function import_spares () {
+setopts var "-d|--disk" "disk" "disk to be replaced"
+setopts var "-s|--spare" "spare" "disk to replace disk defined in -d"
+setopts int "-a|--ashift" "ashift" "ashift value"
+setopts var "-p|-zpool" "zpool" "zpool disk in -d is owned by"
 
-    for i in $(ls /dev/disk/by-id/dm-uuid-mpath* | awk -F "/" '{print $NF}'); do 
-        $zpool status | grep "$i" > /dev/null || ($zpool add "$pool" spare "$i" && echo "Disk ${i} added to ${pool} as hot spare." || echo "Failed to add disk ${i} to ${pool} as hot spare.") 
-    done
+echo -e"zpool ${zpool}:\n\treplacing $disk with $spare"
 
-}
-
-
-#options to be written in at a later date
-setopts flag "-r|--run" "run_flag" "this option starts an automated replacement where a resilver is attempted for all failed disks"
-setopts var "-d|--disk" "faulted_disk" "define a disk to be reslivered with the next available spare disk defined for the pool.\n\t Declaring -d will overwrite -r"
-
-
-###############################################################################################
-################## create zpool array definition ##############################################
-###############################################################################################
-#create array of all zpools
-unset zpool_array
-for pool in $($zpool list -o name -H); do
-    zpool_array+=("$pool") #zpool_array is an array that contains all zpools defined on the system
-done
-
-#uncomment for debugging
-#echo -e "zpool_array\n${zpool_array[@]}"
-
-if [ ${#zpool_array[@]} == 0 ]; then #if the are no items in this array, exit
-    echo -e "\nthere are no zpools defined, there is nothing for this script to do"
-    exit 0
+if [ -z "$ashift" ]; then
+    $zpool replace -o $zpool $disk $spare
+else
+    $zpool replace -o ashift=${ashift}  $zpool $disk $spare
 fi
-###############################################################################################
-###############################################################################################
-###############################################################################################
 
-
-
-for pool in ${zpool_array[@]}; do #read in the list of all zpools
-    
-    import_spares
-    
-    if $zpool status $pool | grep "FAULTED" > /dev/null; then
-
-
-        ###############################################################################################
-        ############################ build faulted drive array ########################################
-        ###############################################################################################
-        #test if FAULTED item is a disk
-        unset faulted_disk_array
-        ledctl_reset_flag=0 #this flag is used in the function beacon_disk to make sure ledctl is only reset 1 time, not each consecutive time it's called, resetting what it's set
-        for faulted_disk in $($zpool status $pool | grep "FAULTED" | awk '{print $1}' | grep -v "raidz" | grep -v "spare"); do #awk out the name of the item
-            faulted_disk_array+=("$faulted_disk") #confirmed as a disk, add to array for replacement
-        done
-        
-        #uncomment for debugging
-        #echo -e "faulted_disk_array\n${faulted_disk_array[@]}"
-    
-        if [ ${#faulted_disk_array[@]} == 0 ]; then #if the are no items in this array, exit
-            echo -e "\nfaulted items exist in the pool, but are not disk items, there is nothing this script can do"
-            exit 1
-        fi
-		
-		#beacon disks
-		echo -e "\nbeaconing disks"
-		$beacon ${faulted_disk_array[@]}
-    
-        echo -e "\ndisk(s) currently in a faulted state: ${faulted_disk_array[@]}"
-        ###############################################################################################
-        ###############################################################################################
-        ###############################################################################################
-
-
-
-        ###############################################################################################
-        #### calculate the number of lines needed to tail out the spare definition in zpool status ####
-        ###############################################################################################
-        if ! $zpool status $pool | grep "spares" > /dev/null; then
-            echo "there are no spares defined for zpool $pool, faulted disks cannot be replaced"
-            exit 1
-        fi
-        total_lines=$($zpool status $pool | wc -l)
-        spares_line_num=$($zpool status $pool | /bin/grep -n "spares" | cut -d ":" -f1) #line number in zpool status where the spares definition starts
-        num_lines_tail=$(( $total_lines - $spares_line_num ))
-        ###############################################################################################
-        ###############################################################################################
-        ###############################################################################################
- 
- 
- 
-        ###############################################################################################
-        ############################ build spare array ################################################
-        ###############################################################################################        
-        unset spare_disk_array
-        unset inuse_spare_array
-        echo -e "\nchecking system for available spares:"
-        for spare_disk in $($zpool status $pool | tail -n $(( $num_lines_tail )) | awk '{print $1}'); do
-            if [ -e /dev/${spare_disk} ] || [ -e /dev/mapper/${spare_disk} ] || [ -e /dev/disk/by-id/${spare_disk} ]; then
-                if $zpool status $pool | grep "$spare_disk" | grep "AVAIL" &> /dev/null; then
-                    echo "AVAIL: $spare_disk"
-                    spare_disk_array+=("$spare_disk")
-                elif $zpool status $pool | grep "$spare_disk" | grep "INUSE" &> /dev/null; then
-                    echo "INUSE: $spare_disk"
-                    inuse_spare_array+=("$spare_disk")
-                else
-                    echo "UNAVAIL: $spare_disk"
-                fi
-            fi
-        done
-        
-        #debugging
-        #echo -e "spare_disk_array\n${spare_disk_array[@]}"
-        #echo -e "inuse_spare_array\n${inuse_spare_array[@]}"
-        
-        if [ ${#spare_disk_array[@]} == 0 ]; then #if the are no items in this array, exit
-            echo "there are no spare disks to resilver data, script must exit"
-            exit 1
-        fi
-        ###############################################################################################
-        ###############################################################################################
-        ###############################################################################################        
-
-
-        ###############################################################################################
-        ########################### find ashift value for the zpool ###################################
-        ###############################################################################################
-        ashift=$($zpool get -H ashift $pool | awk '{print $3}')
-        echo -e "\ndetermined ashift value for $pool is $ashift"
-        ###############################################################################################
-        ###############################################################################################
-        ###############################################################################################
-
-
-
-        ###############################################################################################
-        ############################# replace disk with a spare #######################################
-        ###############################################################################################
-        #replace disk with an AVAIL spare not in use
-        faulted_disk_index=0
-        spare_disk_index=0
-        is_spare_flag=0
-        
-        echo -e "\nstarting disk replacement"
-        for faulted_disk in ${faulted_disk_array[@]}; do
-            for spare_disk in ${spare_disk_array[@]}; do
-                is_spare_flag=0 #reset is_spare_flag
-                if [ "$faulted_disk" == "$spare_disk" ]; then #check if faulted disk is a spare, if so, do not replace, only warn
-                    is_spare_flag=1
-                    echo "faulted disk: $faulted_disk is in the spare pool, will not be replaced"
-                    faulted_disk_index=$(( $faulted_disk_index + 1 ))
-                fi
-            done
-            
-            if [ $is_spare_flag == 0 ]; then #if disk needing replacement is not a spare 
-                next_disk=$($zpool status $pool | grep -A 1  "${faulted_disk_array[$faulted_disk_index]}" | awk '{print $1}' | tail -1)
-                if ! [ -z "$next_disk" ]; then
-                    is_inuse_flag=0
-                    for blah in ${inuse_spare_array[@]}; do
-                        if [ "$blah" == "$next_disk" ]; then
-                            echo "${faulted_disk_array[$faulted_disk_index]} is already being resilvered"
-                            faulted_disk_index=$(( $faulted_disk_index + 1 ))
-                            is_inuse_flag=1
-                        fi
-                    done
-                    if [[ "$is_inuse_flag" == 0 ]]; then #if faulted disk does not have a an in use spare assigned to it
-                        if ! [ -z ${spare_disk_array[$spare_disk_index]} ]; then #if there is a spare
-                            echo -e  "\nreplacing disk ${faulted_disk_array[$faulted_disk_index]} with spare ${spare_disk_array[$spare_disk_index]}"
-                            $zpool replace -o ashift=9 $pool ${faulted_disk_array[$faulted_disk_index]} ${spare_disk_array[$spare_disk_index]}
-                            ret_val=$?
-                            if [ $ret_val != 0 ]; then
-                                echo "failed to replace disk ${faulted_disk_array[$faulted_disk_index]} with spare ${spare_disk_array[$spare_disk_index]}"
-                                echo "exiting due to error"
-                                exit $ret_val
-                            else
-                                echo "replace of ${faulted_disk_array[$faulted_disk_index]} issued successfully"
-                            fi
-                        else
-                            echo -e "**** insufficient spares for the number of faulted drives, cannot continue ****"
-                            exit 1
-                        fi
-                    fi
-                
-                    faulted_disk_index=$(( $faulted_disk_index + 1 )) #interate the next available disk and spare in the array
-                    spare_disk_index=$(( $spare_disk_index + 1 )) #if 
-                else
-                    echo "Cannot determine replacement status for [${faulted_disk}]"
-                fi
-            fi
-            #echo "$faulted_disk_index disk"
-            #echo "$spare_disk_index spare"
-            
-            is_spare_flag=0 #reset spare flag for next loop
-        done
-        ###############################################################################################
-        ###############################################################################################
-        ###############################################################################################        
-        
-        
-    else
-        echo "no faulted disks seen, nothing to do"
-        exit 0
-    fi
-done

--- a/zettaknight.d/setopts.sh
+++ b/zettaknight.d/setopts.sh
@@ -72,6 +72,23 @@ EOF
                                 
                                 eval $var='$val'
                                 
+                            elif [[ $"opt_type" == "int" ]]; then
+                            
+                                arg="${BASH_ARGV[$global_bash_index]}"
+                                val="${BASH_ARGV[$(( $global_bash_index - 1 ))]}"
+                                
+                                if [ "$arg" == "$val" ]; then
+                                    echo "setopts error, $arg must have a value"
+                                    exit 1
+                                fi
+                                
+                                if ! [[ $val =~ ^[-+]?[0-9]+$ ]]; then #test if integer
+                                    echo "$val for $arg is not an integer"
+                                    exit 1
+                                fi
+                                
+                                eval $var='$val'
+                                
                             elif [[ "$opt_type" == "flag" || "$opt_type" == "switch" ]]; then
                                 eval $var=1
                             else

--- a/zettaknight.d/snap_backup.sh
+++ b/zettaknight.d/snap_backup.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+#set -x
+
+SECONDS=0 #bash built in
+
+echo "sync process started: $(date)"
+
+#source helper functions
+running_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+setopts="${running_dir}/setopts.sh"
+find_call="${running_dir}/find_call.sh"
+source $setopts || { echo "failed to source $setopts"; exit 1; }
+source $find_call || { echo "failed to source $find_call"; exit 1; }
+
+function check_previous () {
+    local exit_status=$?
+    local msg="$@"
+
+    if ! [ $exit_status == 0 ]; then
+        echo "${exit_status} : $@"
+        exit 1
+    fi
+}
+
+function check_pipes () {
+    local pipe_exit_status=$(echo ${PIPESTATUS[*]})
+    local msg="$@"
+    n=1
+    for i in $pipe_exit_status; do
+        if ! [ $i == 0 ]; then
+            failed=$(echo "$msg" | cut -d "|" -f${n})
+            echo "$@"
+            if [ $i == 141 ]; then
+                echo "Failed to pipe output of command: $failed"
+                exit 1
+            else
+                echo "$i : $failed"
+                exit 1
+            fi
+        fi
+    n=$(( $n + 1 ))
+    done
+}
+
+function ssh_over () {
+    ssh_cmd="$@"
+
+    if ! [ -z "$priority" ]; then
+
+        if ! [[ -z "$identity_file" ]]; then
+            if [[ -f "$identity_file" ]]; then
+                $ssh -q -i "$identity_file" "$remote_ssh" "$ssh_cmd"
+            else
+                echo "$identity_file is not accessible, cannot use"
+                $ssh -q $remote_ssh "$ssh_cmd"
+            fi
+        else
+            $ssh -q $remote_ssh "$ssh_cmd"
+        fi
+
+    else
+
+        if ! [[ -z "$identity_file" ]]; then
+            if [[ -f "$identity_file" ]]; then
+                $ssh -q -i "$identity_file" "$remote_ssh" "$ssh_cmd"
+            else
+                echo "$identity_file is not accessible, cannot use"
+                $ssh -q $remote_ssh "$ssh_cmd"
+            fi
+        else
+            $ssh -q $remote_ssh "$ssh_cmd"
+        fi
+
+    fi
+
+
+}
+
+#setopts vars
+setopts var "-d|--dataset" "local_dataset" "local_dataset to be replicated"
+setopts var "-r|--remote_dump" "remote_dump" "directory where we're going to put the dump we've taken"
+setopts var "-s|--ssh" "remote_ssh" "Connection string for remote SSH connections, ie. root@somehost.somedomain.com"
+setopts var "-i|--identity" "identity_file" "RSA identity file to use when initiating SSH connections.  Requires full path of identity file."
+setopts var "-t|--timeout" "lock_file_exp" "if lock file still exists for -t hours, send an alert"
+setopts flag "-h|--help" "display_help_flag" "Shows this help dialogue."
+
+#globals
+date_time=$(date '+%Y%m%d_%H%M')
+Local_output_dir="$running_dir"
+remote_user=$(echo ${remote_ssh} | cut -d "@" -f1)
+lock_file=$(echo "sync.${local_dataset}.lock" | tr -d "/")
+lock_file_path=${Local_output_dir}/${lock_file}
+remote_output_dir="/tmp"
+remote_host=$(echo ${remote_ssh} | cut -d "@" -f2)
+
+#determine call locations
+find_call "zfs"
+find_call "ssh"
+
+unset local_snap_array
+for snap in $($zfs list -r -o name -t snapshot -H "${local_dataset}"); do
+
+    local_snap_array+=("$snap")
+
+done
+
+unset remote_dump_array
+for snap in $(ssh_over ls $remote_dump | grep ${local_dataset}@); do
+
+    remote_dump_array+=("$snap")
+
+done
+
+#Have we dumped here before?
+local_last_snapshot=${local_snap_array[${#local_snap_array[@]}-1]}
+local_last_snap=$(echo $local_last_snapshot | awk -F '/' '{print $NF}') #get just the snapshot, not the full path
+
+if ! [ -z "$local_last_snapshot" ]; then #if a local snapshot exists
+
+    if [ "${#remote_dump_array[@]}" -ge 1 ]; then #if a remote snapshot exists
+    
+        remote_last_dump=${remote_dump_array[${#remote_dump_array[@]}-1]}
+    
+        if [ "$local_last_snapshot" != "$remote_last_dump" ]; then #if the local last snap is not the same as the last remote
+            
+            for dump in ${remote_dump_array[@]}; do
+            
+                if [" ${local_dump_array[@]} " =~ ${dump} ]; then
+            
+                    last_match="$snap"
+                    
+                fi
+                
+            done
+
+        fi
+
+    fi
+
+    if [ -z "$last_match" ]; then
+    
+        echo "sending $local_last_snapshot to ${remote_host}:${remote_dump}/${local_last_snap}"
+        $zfs send $local_last_snapshot | ssh_over "cat > ${remote_dump}/${local_last_snap}"
+        check_previous $zfs send $local_last_snapshot | ssh_over "cat > ${remote_dump}/${local_last_snap}"
+        
+    else
+    
+        echo "sending $last_match --> $local_last_snapshot to ${remote_host}:${remote_dump}/${local_last_snap}"
+        $zfs send -I "$last_match" "$local_last_snapshot" | ssh_over "cat > ${remote_dump}/${local_last_snap}"
+        check_previous $zfs send -I "$last_match" "$local_last_snapshot" | ssh_over "cat > ${remote_dump}/${local_last_snap}"
+
+    fi
+
+else
+
+    echo "no snapshots for $local_dataset, dump is not necessary"
+    exit 0
+
+fi

--- a/zettaknight.d/zfs_cleanup_remote_snaps.sh
+++ b/zettaknight.d/zfs_cleanup_remote_snaps.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+#    Copyright (c) 2015-2016 Matthew Carter, Ralph M Goodberlet.
+#
+#    This file is part of Zettaknight.
+#
+#    Zettaknight is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    Zettaknight is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with Zettaknight.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+version="0.0.1"
+#set -x
+
+#source helper functions
+running_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ssh_over="${running_dir}/ssh_over.sh"
+
+source $ssh_over || { echo "failed to source $setopts"; exit 1; }
+
+function show_help () {
+cat <<EOF
+
+version $version
+
+USAGE:
+$0 [dk]
+
+DESCRIPTION:
+        $(basename $0) deletes snapshots that are older than -k days for -d dataset on -s remote machine.
+        This is primarily used for filesystems that have a translated value that cannot be normally synced.
+
+REQUIRED:
+        -d zfs dataset name to delete snapshots from
+        -k delete snapshots that are older than k days
+        -s remote server information <user@hostname>
+        
+OPTIONAL:
+        -i identity file to be used for ssh connection
+
+EOF
+}
+
+function check_previous () {
+                local exit_status=$?
+                if ! [ $exit_status == 0 ]; then
+                        echo "${exit_status} : $@"
+                        exit 1
+                fi
+}
+
+#function ssh_over () {
+#    ssh_cmd="$@"
+#    ssh $remote_ssh "$ssh_cmd"
+#    check_previous "ssh $remote_ssh $@"
+    
+#}
+
+############ flags ################################
+###################################################
+remote_flag=0
+
+############ global var ###########################
+###################################################
+zfs="/sbin/zfs"
+
+#create an ssh key and add it to a remote server
+while getopts "d:k:s:i::?" OPTION
+do
+        case $OPTION in
+                d)
+                        dataset=$OPTARG
+                        ;;
+                k)
+                        day_keep=$OPTARG
+                        ;;
+                s)
+                        remote_ssh=$OPTARG
+                        remote_flag=1
+                        ;;
+                i)
+                        identity_file=$OPTARG
+                        ;;
+                :)
+                        show_help
+                        exit 1
+                        ;;
+                help)
+                        show_help
+                        exit 1
+                        ;;
+        esac
+done
+
+if [ -z "$day_keep" ] || [ -z "$dataset" ] || [ -z "$remote_ssh" ]; then #both arguments are required, exit if either of them are empty
+        echo -e "\n required arguments missing \n"
+        show_help
+        exit 1
+fi
+
+##################### check/create lockfile ######################
+##################################################################
+
+running_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+Local_output_dir="$running_dir"
+lock_file=$(echo "cleanup_snap.${dataset}.lock" | tr -d "/")
+lock_file_path=${Local_output_dir}/${lock_file}
+
+if [[ -f "$lock_file_path" ]]; then
+    echo "$lock_file_path exists for $local_dataset, snap cleanup process cannot continue"
+    exit 1
+else
+    touch "$lock_file_path"
+    check_previous failed to create $lock_file_path
+fi
+
+trap "{ rm -f $lock_file_path; exit; }" INT TERM EXIT
+##################################################################
+##################################################################
+
+
+echo "$dataset: destroying snapshots older than $day_keep days"
+
+IFS=$'\n'
+
+for snap in $(ssh -i $identity_file $remote_ssh "zfs list -r -H -o name,creation -t snapshot $dataset"); do 
+
+    i=$(echo "$snap" | awk '{print $1"@"$3"@"$4"@"$5"@"$6}')
+    snapshot=$(echo "$i" | awk 'BEGIN {FS="@"}{print $1"@"$2}')
+    snapday=$(echo "$i" | awk 'BEGIN {FS="@"}{print $3" "$4" "$5" "$6}')
+    snapsecs=$(date --date="$snapday" +%s)
+    today=$(date +%Y%m%d)
+    todaysecs=$(date --date="$today" +%s)
+
+    sec_old=$(( $todaysecs - $snapsecs ))
+    day_old=$(( $sec_old / 86400 ))
+
+
+    if [[ $day_old -ge $day_keep ]]; then
+
+        ssh -i $identity_file $remote_ssh "zfs destroy $snapshot"
+        
+        if [ $? == 0 ]; then
+        
+            echo "deleted $snapshot"
+        
+        else
+        
+            echo "ERROR: failed to delete $snapshot"
+        
+        fi
+    
+#    else
+        
+#        echo "$snapshot is $day_old day(s) old, this does not exceed the limit of $day_keep day(s)"
+
+    fi
+
+done

--- a/zettaknight.d/zfs_data_generator.sh
+++ b/zettaknight.d/zfs_data_generator.sh
@@ -29,10 +29,17 @@ tail_num=$((${poll_count} - 1))
 outfile="${running_dir}/${date_time}_$(basename $0)"
 
 setopts var "-f|--outfile" "outfile" "file to write results to (default:${outfile})"
+setopts var "-p|--zpool" "zpool" "zpool to show iostat data for, if empty, all pools will be shown"
 
 zpool="/sbin/zpool"
 
-for pool in $($zpool list -H -o name); do
+if [ -z $zpool ]; then
+    mystring="$($zpool list -H -o name)"
+else
+    mystring="$zpool"
+fi
+
+for pool in $mystring; do
     if ! [ -z "$pool" ]; then
         date_log=$(date +'%Y%m%d%H%M%S')
         human_date_log=$(date +'%Y-%m-%d_%H.%M.%S')

--- a/zettaknight.d/zfs_monitor.sh
+++ b/zettaknight.d/zfs_monitor.sh
@@ -18,7 +18,7 @@
 #    along with Zettaknight.  If not, see <http://www.gnu.org/licenses/>.
 #
 #set -x 
-version="0.0.19"
+version="0.0.21"
 
 ###############################################################################
 ###############################################################################
@@ -58,13 +58,20 @@ EOF
 }
 
 function check_previous () {
+
         if [ $? -ne 0 ]; then
+        
                 echo -e "\n$?: $@\n" | tee -a "$logfile"
                 $mail_out "$(hostname) is degraded --- error : $0"
+                
                 if [ -e "$logfile" ]; then
+                
                         rm -f "$logfile"
+                        
                 fi
+                
                 exit 1
+                
         fi
 }
 
@@ -86,7 +93,6 @@ percent_use_flag=0
 
 
 #mail_flag=1
-exe_user=$(cat /etc/passwd | grep $(id -u) | cut -d ":" -f1)
 zpool="/sbin/zpool"
 multipath="/sbin/multipath"
 service="/sbin/service"
@@ -109,10 +115,12 @@ setopts var "-r|--recipient" "message_recipient" "who to send email to in the ev
 ############## check if root ########################
 
 if [ $(id -u) != 0 ]; then #check if ran as root user
+
     echo "$0 needs to be ran as root" | tee -a "$logfile"
     error_flag=1
-    $mail_out "$(hostname) : $exe_user attempted to run $0"
+    $mail_out "$(hostname) : must be ran as root $0"
     exit 1
+    
 fi
 
 #####################################################
@@ -121,97 +129,339 @@ fi
 ############## test pool health #####################
 
 echo -e "\ntesting health of the zpool"
-if $zpool status -x | grep -v "all pools are healthy" &> /dev/null; then
+
+for pool in $($zpool list -o name -H); do
+
+    if $zpool status "$pool" -x | grep -v "pool '$pool' is healthy" &> /dev/null; then
+    
         error_flag=1
-    email_subject="$email_subject: zpool is not healthy"
-        $zpool status -x | tee -a "$logfile"
-        check_previous "$zpool status -x | tee -a $logfile"
+        email_subject="$email_subject: zpool is not healthy"
+        $zpool status "$pool" -x | tee -a "$logfile"
+        
+    else
+    
+        echo "zpool $pool is healthy"
+        
+    fi
+    
     echo -e "\nchecking to see if any disks are in a failed status, if spares are defined a resilver will be started"
-    $replace_disks | tee -a "$logfile"
-    check_previous "failed to issue replacement of failed disk, via $replace_disks"
-else
-    echo "all pool(s) healthy"
-fi
+    
+    
+    if $zpool status $pool | grep "FAULTED" > /dev/null; then
+    
+        unset faulted_disk_array
+        for faulted_disk in $($zpool status $pool | grep "FAULTED" | awk '{print $1}' | grep -v "raidz" | grep -v "spare"); do #awk out the name of the item
+        
+            faulted_disk_array+=("$faulted_disk") #confirmed as a disk, add to array for replacement
+            
+        done
+    
+        if [ ${#faulted_disk_array[@]} != 0 ]; then #if the are items in this array
+        
+            #beacon faulted disks
+            if which ledctl &> /dev/null; then
+            
+                unset disk_array
+            
+                for disk in ${faulted_disk_array[@]}; do
+                
+                    if ! [ -z "$disk" ]; then
+                    
+                        if ls /dev | grep "$disk" > /dev/null; then
+                        
+                            disk_array+=("/dev/${disk}")
+                            
+                        else
+                        
+                            wwid=$(echo "$disk" | awk -F "-" '{print $NF}')
+                            
+                            if ls /dev/disk/by-id | grep "$wwid" > /dev/null; then #if wwid is not empty
+                            
+                                disk_info=$(multipath -ll | grep "$wwid") #whole output to keep from running multipath over and over to determine variables
+                                mpath=$(echo "$disk_info" | awk '{print $1}') #mpathar etc
+                                dm=$(echo "$disk_info" | awk '{print $3}')
+                                devices=$(multipath -ll $mpath | grep ":" | awk '{print $3}') #disks that make up the mpath devices
+
+                                for d in $devices; do
+                                
+                                    disk_array+=("/dev/${d}")
+                                    
+                                done
+
+                            fi
+
+                        fi
+                    fi
+
+                done
+            
+                for disk in ${disk_array[@]}; do
+                
+                    if [ -z "$disk_string" ]; then
+                    
+                        disk_string="$disk"
+                        
+                    else
+                    
+                        disk_string="${disk_string},${disk}"
+                        
+                    fi
+                    
+                done
+
+                echo -e "running:\nledctl failure=$disk_string"
+                ledctl failure="$disk_string"
+                
+            fi
+            #### end beacon disks ####
+        
+            if $zpool status $pool | grep "spares" > /dev/null; then
+            
+                total_lines=$($zpool status $pool | wc -l)
+                spares_line_num=$($zpool status $pool | /bin/grep -n "spares" | cut -d ":" -f1) #line number in zpool status where the spares definition starts
+                num_lines_tail=$(( $total_lines - $spares_line_num ))
+                
+                unset spare_disk_array
+                unset inuse_spare_array
+                echo -e "\nSpares exist, checking for availability:"
+                
+                for spare_disk in $($zpool status $pool | tail -n $(( $num_lines_tail )) | awk '{print $1}'); do
+                
+                    if [ -e /dev/${spare_disk} ] || [ -e /dev/mapper/${spare_disk} ] || [ -e /dev/disk/by-id/${spare_disk} ]; then
+                    
+                        if $zpool status $pool | grep "$spare_disk" | grep "AVAIL" &> /dev/null; then
+                        
+                            echo "AVAIL: $spare_disk"
+                            spare_disk_array+=("$spare_disk")
+                            
+                        elif $zpool status $pool | grep "$spare_disk" | grep "INUSE" &> /dev/null; then
+                            echo "INUSE: $spare_disk"
+                            inuse_spare_array+=("$spare_disk")
+                            
+                        else
+                        
+                            echo "UNAVAIL: $spare_disk"
+                            
+                        fi
+                    fi
+                done
+                
+                if [ ${#spare_disk_array[@]} != 0 ]; then #if the are no items in this array
+                
+                
+                    #determine ashift value for the zpool
+                    ashift=$($zpool get -H ashift $pool | awk '{print $3}')
+                    echo -e "\ndetermined ashift value for $pool is $ashift"
+                    
+                    
+                    #replace disk with an AVAIL spare not in use
+                    faulted_disk_index=0
+                    spare_disk_index=0
+                    is_spare_flag=0
+        
+                    echo -e "\nstarting disk replacement"
+                    for faulted_disk in ${faulted_disk_array[@]}; do
+                    
+                        for spare_disk in ${spare_disk_array[@]}; do
+                        
+                            is_spare_flag=0 #reset is_spare_flag
+                            
+                            if [ "$faulted_disk" == "$spare_disk" ]; then #check if faulted disk is a spare, if so, do not replace, only warn
+                            
+                                is_spare_flag=1
+                                echo "faulted disk: $faulted_disk is in the spare pool, will not be replaced"
+                                faulted_disk_index=$(( $faulted_disk_index + 1 ))
+                            fi
+                            
+                        done
+            
+                        if [ $is_spare_flag == 0 ]; then #if disk needing replacement is not a spare
+                        
+                            next_disk=$($zpool status $pool | grep -A 1  "${faulted_disk_array[$faulted_disk_index]}" | awk '{print $1}' | tail -1)
+                            
+                            if ! [ -z "$next_disk" ]; then
+                            
+                                is_inuse_flag=0
+                                
+                                for blah in ${inuse_spare_array[@]}; do
+                                
+                                    if [ "$blah" == "$next_disk" ]; then
+                                    
+                                        echo "${faulted_disk_array[$faulted_disk_index]} is already being resilvered"
+                                        faulted_disk_index=$(( $faulted_disk_index + 1 ))
+                                        is_inuse_flag=1
+                                        
+                                    fi
+                                    
+                                done
+                                
+                                if [[ "$is_inuse_flag" == 0 ]]; then #if faulted disk does not have a an in use spare assigned to it
+                                
+                                    if ! [ -z ${spare_disk_array[$spare_disk_index]} ]; then #if there is a spare
+                                    
+                                        echo -e  "\nreplacing disk ${faulted_disk_array[$faulted_disk_index]} with spare ${spare_disk_array[$spare_disk_index]}"
+                                        $replace_disk -a $ashift -p $pool -d ${faulted_disk_array[$faulted_disk_index]} -s ${spare_disk_array[$spare_disk_index]} | tee -a "$logfile"
+                                        
+                                    else
+                                    
+                                        echo -e "**** NO SPARES AVAILABLE : ${faulted_disk_array[$faulted_disk_index]} will NOT BE REPLACED ****"
+                                        
+                                    fi
+                                fi
+                
+                                faulted_disk_index=$(( $faulted_disk_index + 1 )) #interate the next available disk and spare in the array
+                                spare_disk_index=$(( $spare_disk_index + 1 )) #if 
+                            else
+                                echo "Cannot determine replacement status for [${faulted_disk}]"
+                            fi
+                        fi
+                        #echo "$faulted_disk_index disk"
+                        #echo "$spare_disk_index spare"
+            
+                        is_spare_flag=0 #reset spare flag for next loop
+                    done
+                
+                else
+                
+                    echo "spares defined for $pool are not available to resilver data" | tee -a $logfile
+                    
+                fi
+            
+            else
+            
+                echo "there are no spares defined for zpool $pool, faulted disks cannot be replaced" | tee -a $logfile
+                
+            fi
+        
+        else
+        
+            echo -e "\nfaulted items exist in the pool, but are not disk items, there is nothing this script can do" | tee -a $logfile
+            
+        fi
+    fi
+    
+    ############## check for silent pool errors ##########
+
+    #check for disk errors
+    echo -e "\nchecking for errors on disks currently ONLINE for $pool"
+    #disk_err_array=()
+
+    while read line; do
+    
+            scrub_flag=0 #if tripped, run a scrub of the pool
+
+            disk=$(echo "$line" | awk '{print $1}')
+            read_err=$(echo "$line" | awk '{print $3}')
+            write_err=$(echo "$line" | awk '{print $4}')
+            chk_sum_err=$(echo "$line" | awk '{print $5}')
+            
+            if [[ $read_err != 0 ]] || [[ $write_err != 0 ]] || [[ $chk_sum_err != 0 ]]; then
+            
+                disk_error_flag=1
+                echo -e "errors detected on ${disk}:\n\t${line}" | tee -a "$logfile"
+                #disk_err_array+=("$disk")
+                
+                
+                if $zpool status $zpool_name | egrep -c "scrub in progress|resilver" &> /dev/null; then
+                
+                    echo -e "\na scrub or resliver is in progress, error correction will resume after completion"
+                
+                else
+                
+                    if [[ "$pool" == "$disk" ]]; then #if you're clearing errors from the zpool itself
+                
+                        $zpool clear $pool
+                        echo -e "errors cleared on $disk\n" | tee -a $logfile
+                        scrub_flag=1
+                
+                    else
+                            
+                        $zpool clear $pool $disk
+                        echo -e "errors cleared on $disk\n" | tee -a $logfile
+                        scrub_flag=1
+                
+                    fi
+                fi
+            fi
+    
+    done < <($zpool status | grep ONLINE | grep -v state)
+
+    if [ $disk_error_flag == 1 ]; then
+
+        email_subject="$email_subject: disk errors detected"
+        
+    else
+
+        echo "no silent errors seen for disks marked online in ZFS filesystem"
+        
+    fi
+    
+    #start a scrub if errors are cleared
+    if [[ $scrub_flag == 1 ]]; then
+    
+        echo -e "due to errors on disks, a scrub will be started for $pool:" | tee -a $logfile
+        $zpool scrub $pool | tee -a $logfile
+        
+    fi 
+      
+done
 
 #####################################################
-
-
-
-
-############## check for silent pool errors ##########
-
-#check for disk errors
-echo -e "\nchecking for errors on disks currently ONLINE for zpool"
-disk_err_array=()
-while read line; do
-        disk=$(echo $line | awk '{print $1}')
-        read_err=$(echo $line | awk '{print $3}')
-        write_err=$(echo $line | awk '{print $4}')
-        chk_sum_err=$(echo $line | awk '{print $5}')
-        
-        out_string="$disk"
-        if [[ $read_err != 0 ]]; then
-            disk_error_flag=1
-            out_string="$out_string read_err=$read_err"
-        fi
-        if [[ $write_err != 0 ]]; then
-            disk_error_flag=1
-            out_string="$out_string write_err=$write_err"
-        fi
-        if [[ $chk_sum_err != 0 ]]; then
-            disk_error_flag=1
-            out_string="$out_string chk_sum_err=$chk_sum_err"
-        fi
-        
-        disk_err_array+=("$out_string")
-
-done < <($zpool status | grep ONLINE | grep -v state)
-
-if [ $disk_error_flag == 1 ]; then
-    email_subject="$email_subject: disk errors detected"
-    for item in ${disk_err_array[@]}; do
-        echo "errors on: $item" | tee -a "$logfile"
-    done
-else
-    echo "no silent errors seen for disks marked online in ZFS filesystem"
-fi
 
 ######################################################
 
 ############ test percent usage for zpool ###########
 
 echo -e "\ntesting defined pools high watermarks and scrub intervals"
+
 while read line; do
+
     zpool_name=$(echo $line | awk '{print $1}')
     capacity=$(echo $line | awk '{print $2}' | cut -d "%" -f 1)
     
 
 
     if $zpool status $zpool_name | egrep -c "scrub in progress|resilver" &> /dev/null; then
+    
         echo "a scrub or resilver is in progress, will resume check after it's completion"
+        
     else
+    
         if $zpool status $zpool_name | egrep -c "none requested" &> /dev/null; then
+        
             echo "a scrub has never been run, this check will monitor frequency after the first scrub of the pool"
+            
         else
+        
             last_scrub_date=$($zpool status $zpool_name | grep scrub | awk '{print $12 " " $13 " " $15}')
             last_scrub_secs=$(/bin/date -d "$last_scrub_date" +%s)
             today_secs=$(/bin/date +%s)
             sec_old=$(( $today_secs - $last_scrub_secs ))
+            
             if [[ $sec_old -gt $scrubExpire ]]; then
+            
                 echo "zpool $zpool_name has not been scrubbed in more than $scrub_days_old days" | tee -a "$logfile"
+                
             else
+            
                 echo "zpool $zpool_name has been scrubbed within the past ${scrub_days_old} day(s)."
+                
             fi
         fi
     fi
     
     if [[ $capacity -gt $zpool_capacity_limit ]]; then
+    
         email_subject="$email_subject: $zpool_name exceeds high watermark"
         percent_use_flag=1
         echo "zpool $zpool_name is ${capacity}% full, exceeds high watermark set at ${zpool_capacity_limit}%" | tee -a "$logfile"
+        
     else
+    
         echo "zpool $zpool_name ${capacity}% full, which is within the limit set of ${zpool_capacity_limit}%"
+        
     fi
+    
 done < <($zpool list -H -o name,capacity)
     
 #####################################################
@@ -220,15 +470,20 @@ done < <($zpool list -H -o name,capacity)
 
 
 if [ -f "$logfile" ]; then
+
     if [ -s "$logfile" ]; then
+    
         echo -e "\nerrors detected, sending contents to: $message_recipient"
         $mail_out -s "$email_subject" -r "$message_recipient" -m "$logfile"
         check_previous $mail_out -s "$email_subject" -r "$message_recipient" -m "$logfile"
         echo "removing logfile: $logfile"
         /bin/rm -f "$logfile"
         check_previous "rm -f $logfile"
-        exit 1
+        
     fi
+    
 else
+
     echo -e "\nall looks good"
+    
 fi

--- a/zettaknight.d/zfs_restore.sh
+++ b/zettaknight.d/zfs_restore.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+#set -x
+#shopt -s failglob
+
+#source helper functions
+running_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+setopts="${running_dir}/setopts.sh"
+
+source $setopts || { echo "failed to source $setopts"; exit 1; }
+
+zfs="/sbin/zfs"
+
+
+function show_help () {
+cat <<EOF
+
+version $version
+
+USAGE:
+$0 [fdzco]
+
+DESCRIPTION:
+        $(basename $0) is used to restore files or directories in zfs filesystems.
+
+OPTIONS:
+        -d directory where listed files are located
+        -f files to be retrieved from directory listed in -d, if -f is empty but -d is declared, script assumes the entire directory should be restored
+        -z zfs dataset defined on the box, this option keeps the script from having to search, saving time
+        -r remote directory location for luks header backups
+        -o if file is greater than specified days old, do not recover
+        -c flag to tell the script to md5 checksum a the restore file if the destination file exists.  Copy with .R extension if difference, do nothing if the same
+        -h Shows this help dialogue.
+EOF
+}
+
+
+
+#setopts var "-f|--files" "files" "files to be retrieved from directory listed in -d, if -f is empty but -d is declared, script assumes the entire directory should be restored"
+#setopts var "-d|--directory" "dataset" "directory where listed files are located"
+#setopts var "-z|--dataset" "final_dataset" "zfs dataset defined on the box, this option keeps the script from having to search, saving time"
+#setopts var "-o|--days" "days_old" "if file is greater than specified days old, do not recover"
+#setopts flag "-c|--checksum" "checksum_flag" "flag to tell the script to md5 checksum a the restore file if the destination file exists.  Copy with .R extension if difference, do nothing if the same"
+#setopts flag "-h|--help" "display_help_flag" "Shows this help dialogue."
+
+
+
+while getopts "f:d:z:co:?" OPTION
+do
+     case $OPTION in
+        f)
+            files=$OPTARG
+            echo "files argument is $files"
+            ;;
+        d)
+            dataset=$OPTARG
+            case $dataset in
+                /*) ;;
+                *) dataset="/${dataset}";;
+            esac
+            ;;
+        z)
+            final_dataset=$OPTARG
+            case $final_dataset in
+                /*) final_dataset=${final_dataset#'/'};;
+                *) ;;
+            esac
+            ;;
+        c)
+            checksum_flag=1
+            ;;
+        o)
+            days_old=$OPTARG
+            ;;
+        :)
+            show_help
+            exit 1
+            ;;
+        help)
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+
+if [ -z "$dataset" ]; then
+
+    echo "required arguments missing, missing -d"
+    show_help
+    exit 1
+    
+fi
+
+if [ -z "$days_old" ]; then
+
+    days_old=999999 #set a farsical days old number if not specified
+
+fi
+
+
+###################### find the zfs dataset in the path given #########################
+#######################################################################################
+
+
+if [[ -z "$final_dataset" ]]; then
+
+    defined_datasets=$(zfs list -o name -H)
+    found_flag=0
+
+    case $dataset in
+            /*) ;;
+            *) dataset="/${dataset}";;
+    esac
+
+
+    zfs_dataset="$dataset"
+
+    case $zfs_dataset in
+            *) ;;
+            /*) zfs_dataset=$(echo "${dataset}" | sed -e 's@^/@@');;
+    esac
+
+
+    while [[ "$zfs_dataset" != "." ]]; do
+
+        if [[ $found_flag != 0 ]]; then
+    
+            break
+    
+        fi
+
+        for defined_dataset in $defined_datasets; do
+
+            if [ "$defined_dataset" == "$zfs_dataset" ]; then
+        
+                if [[ $found_flag == 0 ]]; then
+    
+                    final_dataset="$zfs_dataset"
+                    echo "determined zfs dataset is $final_dataset"
+                    found_flag=1
+                    break
+                
+                fi
+    
+            fi
+
+        done
+    
+        zfs_dataset=$(dirname "$zfs_dataset")
+    
+    done
+
+    if [ "$zfs_dataset" == "." ]; then
+        
+            echo "no zfs dataset can be found in $dataset, script must exit"
+            exit 1
+        
+    fi
+    
+fi
+
+#######################################################################################
+#######################################################################################
+
+
+################ search snapshots for file/dir ########################################
+#######################################################################################
+
+
+#get the reverse order of snaps, newest snapshot first
+snapshots=$(zfs list -t snapshot -o name -H | grep "$final_dataset" | awk -F '@' '{print $NF}' | sort -r -n)
+
+if [[ -z "$files" ]]; then
+    #if no files given, get all directory
+
+    echo "haven't done this yet"
+    
+else
+
+    unset restored_files
+    declare restored_files
+
+    #if files, go get those files
+    for file in $files; do
+    
+        found_flag=0
+        
+        echo -e "\nlooking for file [$file]"
+        
+        for snapshot in $snapshots; do
+            
+            #echo -e "\tlooking in snapshot [$snapshot]"
+        
+            restore_from_dir=$(echo "$dataset" | sed -e "s@${final_dataset}@${final_dataset}/.zfs/snapshot/${snapshot}@")
+            
+            glob_expand=$(echo ${restore_from_dir}/${file})
+            
+            for f in $glob_expand; do
+            
+                if [[ -e "${f}" ]]; then
+            
+                    found_flag=1
+                    restored_file=$(echo "$f" | awk -F '/' '{print $NF}')
+                    
+                    if ! [[ " ${restored_files[@]} " =~ " ${restored_file} " ]]; then
+                        
+                        if [ ! -e "${dataset}/${f}" ] && [ ! -e "${dataset}/${f}.R" ]; then
+                        
+                            file_mtime=$(stat -c %Y $f)
+                            curr_time=$(date +%s)
+                            file_days=$(( (currtime - filemtime) / 86400 ))
+                            
+                            if [[ "$file_days" -ge "$days_old" ]]; then
+                            
+                                echo "file [ $f ] is older than $days_old day(s), will not restore"
+                                
+                            else
+                        
+                                cp "$f" "${dataset}/$restored_file.R"
+                                
+                                if [ $? -eq 0 ]; then
+                                
+                                    echo -e "\t[SUCCESS] file ${dataset}/$restored_file.R recovered from snapshot $snapshot"
+                                    restored_files+=("$restored_file")
+                                    
+                                else
+                                
+                                    echo -e "\t[FAILURE] file ${dataset}/$restored_file.R failed to recover from snapshot $snapshot"
+                                    restored_files+=("$restored_file")
+                                    
+                                fi
+                                
+                            fi
+                            
+                        else
+                        
+                            echo -e "\t[WARNING] file [ ${dataset}/${f} ] already exists or has already been recovered, will not overwrite"
+                            restored_files+=("$restored_file")
+                        
+                        fi                    
+                            
+                    fi
+                        
+                fi
+                        
+            done
+
+        done
+            
+        if [[ $found_flag == 0 ]]; then
+    
+            echo -e "\t[WARNING] cannot find file [ $file ] in any snapshot, please verify filename"
+    
+        fi
+
+    done
+
+fi

--- a/zettaknight_globs.py
+++ b/zettaknight_globs.py
@@ -18,86 +18,67 @@
 #    along with Zettaknight.  If not, see <http://www.gnu.org/licenses/>.
 #
 # -*- coding: utf-8 -*-
- 
- 
-###############################################################################################
-################################ user definitions #############################################
-###############################################################################################
- 
-pool_name = "zfs_data"
-zpool_ashift = 9 #ashift value should be 9 for 512 byte sector disks, 12 for 4k byte disks
-zpool_disk_list = "/tmp/disk_list.txt" #list of disks separated by newline to be used in zpool creation
- 
-#if no contact information is provided within the configuration file
-#zettaknight will contact this/these address(es) by default
-#multiple entires should be separated by a space
-default_contact_info = False
- 
-#Optional MatterMost webhook integration
-mm_flag = False
-mm_webhook = False
-mm_icon = False
- 
+
 ###############################################################################################
 ################## DO NOT MODIFY ANYTHING BELOW THIS LINE #####################################
 ###############################################################################################
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
 # Import python libs
 import socket
 import os
 import datetime
- 
- 
+
+
 #zettaknight's current version
-version = "0.0.9" 
- 
+version = "0.0.9"
+
 #version of python required by zettaknight
 required_python_version = "2.x"
- 
+
 #variable to determine the fully qualified domain name of the system
 fqdn = socket.getfqdn()
 
+#needs to be removed when order YAML dict is in place
+pool_name = "zfs_data"
+
 #zfs dataset definition for store information for zettaknight, config files and keys will reside here
 zettaknight_store = "{0}/zettaknight/{1}".format(pool_name, fqdn)
- 
+
 #determines the current date
 today_date = str(datetime.datetime.today().strftime('%Y%m%d_%H%M'))
 today_date2 = str(datetime.datetime.today().strftime('%Y%m%d'))
 
-#variable to determine the logging level for zlog
-level_zlog = "WARNING"
- 
 #the following sets the directory this file is in as the base for where all
 #other files necessary for zettaknight are referenced
- 
+
 abspath = os.path.realpath(__file__)
 base_dir = os.path.dirname(abspath)
 script_dir = os.path.dirname("{0}/zettaknight.d/".format(base_dir))
 conf_dir = os.path.dirname("{0}/zettaknight.conf.d/".format(base_dir))
 conf_dir_new = os.path.dirname("/etc/zettaknight/")
-conf_dir_final = os.path.dirname("/{0}".format(zettaknight_store)) #add leading slash, zfs share
- 
+#conf_dir_final = os.path.dirname("/{0}".format(zettaknight_store)) #add leading slash, zfs share
+
 #############################################################################################
 #############################################################################################
- 
+
 #crypt_dir stores the ssh key used for both luks encryption and ssh transfers between servers
 #two options are available below, one is root and the other within zettaknight's operating directory
- 
+
 #crypt_dir = os.path.dirname("{0}/.zettaknight.crypt/".format(base_dir))
 crypt_dir = "/root/.ssh/.zettaknight_crypt"
 luks_header_dir = "{0}/luks_header_backups".format(crypt_dir)
- 
+
 #the identity file is the name of the key used for luks and ssh communication for zettaknight
 identity_file = "{0}/zettaknight.id".format(crypt_dir)
- 
+
 #############################################################################################
 #############################################################################################
- 
+
 #the config file is a yaml file used in all processes of zettaknight.  This sets the configuration
 #on which zettaknight does it automated processes.
 
@@ -108,6 +89,9 @@ config_file_new = "{0}/{1}.conf".format(conf_dir_new, fqdn)
 default_pool_config_file = "{0}/default_pool_conf_file.yml".format(conf_dir)
 pool_config_file = "{0}/{1}_zpool.conf".format(conf_dir_new, fqdn)
 
+default_zettaknight_config_file = "{0}/default_zettaknight_conf_file.yml".format(conf_dir)
+zettaknight_config_file = "{0}/zettaknight.conf".format(conf_dir_new)
+
 #cron.d files
 crond_primary = "/etc/cron.d/{0}_primary_datasets".format(fqdn)
 crond_secondary = "/etc/cron.d/{0}_secondary_datasets".format(fqdn)
@@ -116,15 +100,20 @@ crond_zettaknight = "/etc/cron.d/zettaknight"
 #stats file
 zpool_perf_dir = "/{0}/zettaknight_stats".format(zettaknight_store)
 zpool_iostat_file = "{0}/{1}_zpool_iostat_file".format(zpool_perf_dir, today_date2)
- 
+
+#mtime file
+mtime_file = "/{0}/zettaknight_mtime_{1}".format(zettaknight_store, fqdn)
+zpool_mtime_file = "/{0}/zettaknight_zpool_mtime_{1}".format(zettaknight_store, fqdn)
+
 #############################################################################################
 #############################################################################################
- 
- 
+
+
 #the following are locations for scripts that zettaknight uses for various processes
- 
+
 snap_script = "{0}/zfs_snap.sh".format(script_dir)
 cleanup_script = "{0}/zfs_cleanup_snaps.sh".format(script_dir)
+cleanup_remote_script = "{0}/zfs_cleanup_remote_snaps.sh".format(script_dir)
 quota_script = "{0}/zfs_quota.sh".format(script_dir)
 luks_key_script = "{0}/luks_key_manage.sh".format(script_dir)
 luks_header_backup_script = "{0}/luks_header_backup.sh".format(script_dir)
@@ -138,20 +127,22 @@ cifs_share_script = "{0}/zfs_cifs_add_share.sh".format(script_dir)
 sync_script = "{0}/sync.sh".format(script_dir)
 hpnssh_script = "{0}/hpnssh.sh".format(script_dir)
 perf_stats_script = "{0}/zfs_data_generator.sh".format(script_dir)
- 
+backup_snap_script = "{0}/snap_backup.sh".format(script_dir)
+
 #default flags for varius functions in zettaknight's entry_point
- 
+
 mail_flag = False
 mail_error_flag = False
 nocolor_flag = False
 help_flag = False
- 
+
 #default names for zpools and cifs/nfs datasets
 cifs_dset_suffix = "cifs"
 nfs_dset_suffix = "nfs"
- 
+
 #############################################################################################
 #############################################################################################
- 
+
 zfs_conf = {}
 zpool_conf = {}
+zettaknight_conf = {}

--- a/zettaknight_utils.py
+++ b/zettaknight_utils.py
@@ -59,38 +59,40 @@ def zlog(*args):
     ret = ""
     
     date = datetime.datetime.today()
-    
-    if level.upper() == "DEBUG":
-        level_int = 5
-    if level.upper() == "INFO":
-        level_int = 4
-    if level.upper() == "WARNING":
-        level_int = 3
-    if level.upper() == "ERROR":
-        level_int = 2
-    if level.upper() == "CRITICAL":
-        level_int = 1
         
     #test if level_zlog in globs is a string or int
-    if not isinstance(zettaknight_globs.level_zlog, int):
-        if zettaknight_globs.level_zlog == "DEBUG":
-            zettaknight_globs.level_zlog = 5
-        if zettaknight_globs.level_zlog == "INFO":
-            zettaknight_globs.level_zlog = 4
-        if zettaknight_globs.level_zlog == "WARNING":
-            zettaknight_globs.level_zlog = 3
-        if zettaknight_globs.level_zlog == "ERROR":
-            zettaknight_globs.level_zlog = 2
-        if zettaknight_globs.level_zlog == "CRITICAL":
-            zettaknight_globs.level_zlog = 1
+    if zettaknight_globs.zettaknight_conf is not None:
     
-    if zettaknight_globs.level_zlog >= 5:
+        if 'level_zlog' not in zettaknight_globs.zettaknight_conf.iterkeys():
+        
+            level_int = 4
+    
+        else:
+
+            if not isinstance(zettaknight_globs.zettaknight_conf['level_zlog'], int):
+        
+                if zettaknight_globs.zettaknight_conf['level_zlog'] == "DEBUG":
+                    level_int = 5
+                if zettaknight_globs.zettaknight_conf['level_zlog'] == "INFO":
+                    level_int = 4
+                if zettaknight_globs.zettaknight_conf['level_zlog'] == "WARNING":
+                    level_int = 3
+                if zettaknight_globs.zettaknight_conf['level_zlog'] == "ERROR":
+                    level_int = 2
+                if zettaknight_globs.zettaknight_conf['level_zlog'] == "CRITICAL":
+                    level_int = 1
+                    
+    else: #if zettaknight_conf is empty, allows ERROR and CRITICAL messages to be reported to standard out
+    
+        level_int = 4
+    
+    if level_int >= 5:
     
         if level.upper() == "DEBUG":
             level = printcolors("{0}".format(level.upper()), "OKBLUE")
             ret = "{0} {1} {2}".format(date, level, message)
     
-    if zettaknight_globs.level_zlog >= 4:
+    if level_int >= 4:
     
         if level.upper() == "INFO":
             level = printcolors("{0}".format(level.upper()), "OKBLUE")
@@ -100,17 +102,17 @@ def zlog(*args):
             level = printcolors("{0}".format(level.upper()), "OKGREEN")
             ret = "{0} {1} {2}".format(date, level, message)
         
-    if zettaknight_globs.level_zlog >= 3:
+    if level_int >= 3:
         if level.upper() == "WARNING":
             level = printcolors("{0}".format(level.upper()), "WARNING")
             ret = "{0} {1} {2}".format(date, level, message)
         
-    if zettaknight_globs.level_zlog >= 2:
+    if level_int >= 2:
         if level.upper() == "ERROR":
             level = printcolors("{0}".format(level.upper()), "FAIL")
             ret = "{0} {1} {2}".format(date, level, message)
         
-    if zettaknight_globs.level_zlog >= 1:
+    if level_int >= 1:
         if level.upper() == "CRITICAL":
             level = printcolors("{0}".format(level.upper()), "HEADER")
             ret = "{0} {1} {2}".format(date, level, message)
@@ -202,6 +204,8 @@ def mail_out(email_message, email_subject, email_recipient):
     
  
 def parse_output(out_dict):
+
+    zlog("parse_output started, dict obj passed:\n\t{0}".format(out_dict), "DEBUG")
     
     '''
     accepts information in the following format 
@@ -214,8 +218,8 @@ def parse_output(out_dict):
     handler = logging.handlers.SysLogHandler(address = '/dev/log')
     Zlogger.addHandler(handler)
 
-    if zettaknight_globs.mm_flag:
-        zettaknight_globs.nocolor_flag = True
+#    if zettaknight_globs.mm_flag:
+#        zettaknight_globs.nocolor_flag = True
 
     for dataset in out_dict.iterkeys():
         json_out = {}
@@ -267,11 +271,11 @@ def parse_output(out_dict):
             global_ret = "{0}{1}\n".format(global_ret, msg)
             
         print(global_ret)
-        if zettaknight_globs.mm_flag:
-            mm_msg = re.sub("[├─┬┐]", "", global_ret)
-            mm_msg = re.sub("%", " percent", mm_msg)
-            mm_msg = re.sub("    ", "", mm_msg)
-            mm_post(mm_msg)
+ #       if zettaknight_globs.mm_flag:
+ #           mm_msg = re.sub("[├─┬┐]", "", global_ret)
+ #           mm_msg = re.sub("%", " percent", mm_msg)
+ #           mm_msg = re.sub("    ", "", mm_msg)
+ #           mm_post(mm_msg)
         
         if zettaknight_globs.mail_flag or mail_this:
             global_ret = "Zettaknight:\n{0}{1}".format(a, global_ret)
@@ -279,10 +283,10 @@ def parse_output(out_dict):
                 contact = zettaknight_globs.zfs_conf[dataset]['contact']
             except KeyError:
                 contact = zettaknight_globs.default_contact_info
- 
+
             mail_sub = re.sub("[├─┬┐]", "", a)
             mail_msg = re.sub("[├─┬┐]", "", global_ret) #re.sub = regular expression substitution (sed)
-            
+
             send_mail = mail_out(mail_msg, "Job report for Dataset: {0}, on {1}".format(dataset, zettaknight_globs.fqdn), contact)
  
     return global_ret
@@ -993,6 +997,7 @@ def backup_files(*args):
     ret[zettaknight_globs.fqdn][zettaknight_globs.zettaknight_store]['0'] = {}
     ret[zettaknight_globs.fqdn][zettaknight_globs.zettaknight_store]['1'] = {}
     
+    
     zettaknight_store = zettaknight_globs.zettaknight_store
     
     if args:
@@ -1095,8 +1100,12 @@ def create_crond_file():
             cron_monitor_line = update_crond(cron_monitor, everyhour=1, minute=0)
             zlog("{0} --> {1}".format(cron_monitor_line, myfile), "DEBUG")
             myfile.write("{0}\n".format(cron_monitor_line))
-
-            sync_monitor = "root {0}/zettaknight.py mail_error sync_all &> /dev/null".format(zettaknight_globs.base_dir)
+            
+            if _str_to_bool(zettaknight_globs.zettaknight_conf['parallel']):
+                sync_monitor = "root {0}/zettaknight.py mail_error sync_all parallel=True &> /dev/null".format(zettaknight_globs.base_dir)
+            else:
+                sync_monitor = "root {0}/zettaknight.py mail_error sync_all &> /dev/null".format(zettaknight_globs.base_dir)
+                
             sync_monitor_line = update_crond(sync_monitor, everyhour=1, minute=0)
             zlog("{0} --> {1}".format(sync_monitor_line, myfile), "DEBUG")
             myfile.write("{0}\n".format(sync_monitor_line))
@@ -1110,6 +1119,11 @@ def create_crond_file():
             zpool_iostat_line = update_crond(zpool_iostat, everyminute=5)
             zlog("{0} --> {1}".format(zpool_iostat_line, myfile), "DEBUG")
             myfile.write("{0}\n".format(zpool_iostat_line))
+            
+            enforce_config_run = "root {0}/zettaknight.py mail_error enforce_config &> /dev/null".format(zettaknight_globs.base_dir)
+            enforce_config_run_line = update_crond(enforce_config_run, everyminute=10)
+            zlog("{0} --> {1}".format(enforce_config_run_line, myfile), "DEBUG")
+            myfile.write("{0}\n".format(enforce_config_run_line))
         
         with open(crond_zettaknight, "r") as myfile:
         
@@ -1234,6 +1248,9 @@ def create_crond_file():
                                 
                                 zlog("{0} --> {1}".format(zpool_iostat_line, zettaknight_globs.crond_zettaknight), "DEBUG")
                                 f.write("{0}\n".format(zpool_iostat_line))
+                                
+                                zlog("{0} --> {1}".format(enforce_config_run_line, zettaknight_globs.crond_zettaknight), "DEBUG")
+                                f.write("{0}\n".format(enforce_config_run_line))
                                 
                                 
                                 f.close()
@@ -1363,20 +1380,6 @@ def install_hpnssh(**kwargs):
     ret[zettaknight_globs.fqdn]['install hpnssh'] = spawn_job(hpnssh_cmd)
     
     return ret
- 
-def create_store(store):
-    '''
-    this function is designed to create the zfs dataset necessary for zettaknight to pass
-    it's configuration files around to non-primary nodes
-    '''
-    
-    if not store:
-        store = ""
-    
-    
-    
-#def check_dataset_exists(dataset):
-
 
 def _str_to_bool(var):
     if isinstance(var, bool):
@@ -1389,7 +1392,6 @@ def _str_to_bool(var):
             return False
             
     return None
-    
     
 def mm_post(message):
     '''


### PR DESCRIPTION
diskperf_one_run.sh - fixed indentation

luks_disk_create.sh - wrote shell script to take a disk and a keyfile arugment and create a luks volume on that disk.  The keyfile will be added as the only unlock method for that disk.  Disk information will be added to /etc/crypttab.  Future release will have configurable cypher options

replace_disk.sh - removed the "brains" and moved the decision making back to zfs_monitor.sh.  Replace disk now takes a disk argument and replaces it with the spare disk arguemnt.  Ashift and zpool information are required.

setopts.sh - added an int option.  Exits if submitted int variable is not an int.

snap_backup.sh - written as an option before translate had been fully written.  This served a very specific purpose that I'm likely going to depricate in the near future.  However, it has been used in a snall subset, so it's included here.

sync.sh - Now supports a translated dataset name.  It now can translate a local dataset of zfs/my_data as zfs_pool2/some/other/dir.

cleanup_remote_snaps.sh - translated datasets cannot delete remote snapshots like filesystems syncing with the -R flag.  This will clean up remote defined dataset snaps.  Future will cleanup DGR defined sets as well.

zfs_data_generator.sh - functionality improvements

zfs_monitor.sh - complete overhaul.  The original parsing of disk imformation done in replace disk made it difficult for monitor to do many of the tasks it was responsible for.  That has been moved here.  If errors exist on a pool without zfs failing the vdev, monitor will not reset the error counters and initiate a scrub of the zpool.  Functionaility improvements of the way monitor handles the spare, failed_disk, and reserve disk arrays.  Future will remove mail functionaility from montior and return it to the python calliing process.

zfs_restore.sh - restores files or directories in a zfs dataset without the use of zfs diff.  Diff works, but has been cripplingly slow, prompting the avoidance in this script.  file argument accepts and expands file globbing.  If -z is not given and the script is allowed to find the zfs_dataset, a performance penalty is incurred.  Next version will change the search query to eliminate outliers before digging into each directory structure.

zettaknight.py - zlog informtaion for all running levels added.  Calls for backup_server, translate, timeout, and priority all added.  Critical checks for zpool contact information.  Proper creation and assignment of zettaknight_store.  New configuration dictionaries added, zpool_conf and zettaknight_conf.  Critical checks for these files existance in /etc/zettaknight.

zettaknight_globs.py - many additions for new functions and features written into zettaknight.

zettaknight_utils.py - fixed issue where level_zlog wouldn't be set if zettaknight_conf errored out. Wrote in parallel option for dataset syncing.  Option exists in zettaknight_conf which will allow all datasets to sync at once.  Next release will have a floodgate which will allow how many can sync at once. Enforce_pool_config and enforce_zpool_config have been added.  They are separate running processes that both have a force option.  If force is false, the process checks respective configuration files, the process only runs if the files have been modified since it's last run.

zettaknight_zfs.py - necessary additions to support the features added.  Translate, etc.  Wrote a touch function to establish mtime values for last modification times of config files.





