### PR TITLE
Fix kwargs parsing in add_dataset

### DIFF
--- a/zettaknight_zfs.py
+++ b/zettaknight_zfs.py
@@ -1036,11 +1036,11 @@ def add_dataset(dataset, **kwargs):
     ret[zettaknight_globs.fqdn] = {}
     question = False
     if 'create_config' in kwargs.iterkeys():
-        create_config = kwargs['create_config']
+        create_config = (kwargs['create_config'] == "True")
     else:
         create_config = True
     if 'nfs' in kwargs.iterkeys():
-        nfs = kwargs['nfs']
+        nfs = (kwargs['nfs'] == "True")
     else:
         nfs = True    
     #append dataset to kwargs


### PR DESCRIPTION
Variables set to boolean values instead of strings if specified in the command line arguments.